### PR TITLE
Tell shlibdeps where to find vendor libraries.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -50,7 +50,7 @@ override_dh_shlibdeps:
 	# in the install tree that was dropped by catkin, and source it.  It will
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/
+	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/:$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/opt/rviz_assimp_vendor/lib/
 
 override_dh_auto_install:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
Cherry picked from bouncy where we do the same thing.