### PR TITLE
Don't release rviz_rendering_tests into crystal.

### DIFF
--- a/crystal.ignored
+++ b/crystal.ignored
@@ -1,1 +1,2 @@
 rviz
+rviz_rendering_tests


### PR DESCRIPTION
@wjwwood per our discussion offline I'm going to merge this and rev rviz with the recently merged patches. Depending on how the visual testing framework goes another rev with patches applied to it might be needed. 