### PR TITLE
Pass through CMAKE_{C,CXX}_FLAGS to OGRE build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,8 @@ endmacro()
 
 macro(build_ogre)
   set(extra_cmake_args)
-  set(OGRE_CXX_FLAGS)
+  set(OGRE_C_FLAGS ${CMAKE_C_FLAGS})
+  set(OGRE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
   # standard library is important for linking, but the other cxx flags are not
   if(CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -stdlib=libc++")
@@ -113,19 +114,20 @@ macro(build_ogre)
   endif()
 
   if(WIN32)
+    set(OGRE_C_FLAGS "${OGRE_C_FLAGS} /w /EHsc")
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} /w /EHsc")
-    list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=/w /EHsc")
   elseif(APPLE)
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -std=c++14 -stdlib=libc++ -w")
     list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='x86_64'")
   else()  # Linux
+    set(OGRE_C_FLAGS "${OGRE_C_FLAGS} -w")
     # include Clang -Wno-everything to disable warnings in that build. GCC doesn't mind it
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -std=c++14 -w -Wno-everything")
-    list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=-w")
   endif()
   list(APPEND extra_cmake_args "-DOGRE_BUILD_RENDERSYSTEM_GL:BOOL=TRUE")
   list(APPEND extra_cmake_args "-DOGRE_BUILD_RENDERSYSTEM_D3D11:BOOL=OFF")
   list(APPEND extra_cmake_args "-DOGRE_BUILD_RENDERSYSTEM_D3D9:BOOL=OFF")
+  list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=${OGRE_C_FLAGS}")
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${OGRE_CXX_FLAGS}")
 
   # Uncomment this line to enable the GL3PLUS render engine


### PR DESCRIPTION
Original change, which is currently released in `rolling`: ros2/rviz#587

The motivation for backporting it here is that RPM debuginfo extraction relies on build IDs that are enabled by these flags. Ensuring proper debuginfo extraction will reduce the size of the RPM substantially.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.