### PR TITLE
rviz_common: Remove variadic macro warning check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,6 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
-  # TODO(wjwwood): try to remove this -- currently needed to pass on CI
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(-Wno-gnu-zero-variadic-macro-arguments HAS_W_FLAG)
-  if(HAS_W_FLAG)
-    add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
-  endif()
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Original change, which is currently released in `rolling`: ros2/rviz#421

This build will fail on CentOS 7 without this change.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.