### PR TITLE
Drop system assimp dependency to force vendoring

### DIFF
--- a/rpm/ros-rolling-rviz-assimp-vendor.spec
+++ b/rpm/ros-rolling-rviz-assimp-vendor.spec
@@ -14,9 +14,7 @@ License:        Apache License 2.0
 URL:            http://assimp.sourceforge.net/index.html
 Source0:        %{name}-%{version}.tar.gz
 
-Requires:       assimp-devel
 Requires:       ros-rolling-ros-workspace
-BuildRequires:  assimp-devel
 BuildRequires:  ros-rolling-ament-cmake
 BuildRequires:  ros-rolling-ament-cmake-lint-cmake
 BuildRequires:  ros-rolling-ament-cmake-xmllint


### PR DESCRIPTION
There's a problem with the assimp 5.0.1 CMake targets that causes them to fail on systems that use `LIB_SUFFIX`, like RedHat distributions do. Unfortunately, the failure causes `find_package(assimp)` to fail even if `QUIET` is specified.

Dropping the dependency (for now) will force the vendor package to build from source instead.

Here's the fix I've proposed to the system package. If that fix goes stable, we can drop this patch.
https://src.fedoraproject.org/rpms/assimp/pull-request/2

I will **fast-forward merge** this change when it has been reviewed.