### PR TITLE
Tell dh_shlibdeps where to find rviz_ogre_vendor plugin libraries

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -51,7 +51,7 @@ override_dh_shlibdeps:
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/:$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/opt/rviz_ogre_vendor/lib/
+	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/:$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/opt/rviz_ogre_vendor/lib/:$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/opt/rviz_ogre_vendor/lib/OGRE/
 
 
 override_dh_auto_install:


### PR DESCRIPTION
As of https://github.com/ros2/rviz/pull/688, `rviz_ogre_vendor` plugin libraries that depend on other plugin libraries no longer have an RPATH for `dpkg-shlibdeps` to find them.