### PR TITLE
Update humble devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -189,7 +189,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: ros2
+    devel_branch: humble
     last_version: 11.2.0
     name: rviz
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for humble to match the source branch as specified in https://github.com/ros/rosdistro/humble/distribution.yaml .
